### PR TITLE
return number of processed items and Abort error

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -13,7 +13,7 @@ var Abort = errors.New("done")
 
 // All calls eachFn for all items
 // Returns any error from eachFn except for Abort it returns nil.
-func All(count, batchSize int, eachFn BatchFunc) error {
+func All(count, batchSize int, eachFn BatchFunc) (int, error) {
 	i := 0
 	for i < count {
 		end := i + batchSize - 1
@@ -23,9 +23,9 @@ func All(count, batchSize int, eachFn BatchFunc) error {
 		}
 		err := eachFn(i, end)
 		if err != nil {
-			return err
+			return i, err
 		}
 		i = end + 1
 	}
-	return nil
+	return i, nil
 }

--- a/batch.go
+++ b/batch.go
@@ -22,9 +22,6 @@ func All(count, batchSize int, eachFn BatchFunc) error {
 			end = count - 1
 		}
 		err := eachFn(i, end)
-		if err == Abort {
-			return nil
-		}
 		if err != nil {
 			return err
 		}

--- a/batch_test.go
+++ b/batch_test.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/pacedotdev/batch"
 	"github.com/matryer/is"
+	"github.com/pacedotdev/batch"
 )
 
 func Test(t *testing.T) {
@@ -104,7 +104,7 @@ func TestAbort(t *testing.T) {
 		})
 		return batch.Abort
 	})
-	is.NoErr(err)
+	is.Equal(err, batch.Abort)
 	is.Equal(len(ranges), 1)
 	is.Equal(ranges[0].start, 0)
 	is.Equal(ranges[0].end, 9)

--- a/batch_test.go
+++ b/batch_test.go
@@ -15,7 +15,7 @@ func Test(t *testing.T) {
 		start, end int
 	}
 	var ranges []r
-	err := batch.All(100, 10, func(start, end int) error {
+	n, err := batch.All(100, 10, func(start, end int) error {
 		ranges = append(ranges, r{
 			start: start,
 			end:   end,
@@ -23,7 +23,7 @@ func Test(t *testing.T) {
 		return nil
 	})
 	is.NoErr(err)
-
+	is.Equal(n, 100)
 	is.Equal(len(ranges), 10)
 	is.Equal(ranges[0].start, 0)
 	is.Equal(ranges[0].end, 9)
@@ -54,7 +54,7 @@ func TestHalfPages(t *testing.T) {
 		start, end int
 	}
 	var ranges []r
-	err := batch.All(15, 10, func(start, end int) error {
+	n, err := batch.All(15, 10, func(start, end int) error {
 		ranges = append(ranges, r{
 			start: start,
 			end:   end,
@@ -62,6 +62,7 @@ func TestHalfPages(t *testing.T) {
 		return nil
 	})
 	is.NoErr(err)
+	is.Equal(n, 15)
 	is.Equal(len(ranges), 2)
 	is.Equal(ranges[0].start, 0)
 	is.Equal(ranges[0].end, 9)
@@ -77,7 +78,7 @@ func TestTinyPages(t *testing.T) {
 		start, end int
 	}
 	var ranges []r
-	err := batch.All(1, 10, func(start, end int) error {
+	n, err := batch.All(1, 10, func(start, end int) error {
 		ranges = append(ranges, r{
 			start: start,
 			end:   end,
@@ -85,6 +86,7 @@ func TestTinyPages(t *testing.T) {
 		return nil
 	})
 	is.NoErr(err)
+	is.Equal(n, 1)
 	is.Equal(len(ranges), 1)
 	is.Equal(ranges[0].start, 0)
 	is.Equal(ranges[0].end, 0)
@@ -97,7 +99,7 @@ func TestAbort(t *testing.T) {
 		start, end int
 	}
 	var ranges []r
-	err := batch.All(20, 10, func(start, end int) error {
+	n, err := batch.All(20, 10, func(start, end int) error {
 		ranges = append(ranges, r{
 			start: start,
 			end:   end,
@@ -105,6 +107,7 @@ func TestAbort(t *testing.T) {
 		return batch.Abort
 	})
 	is.Equal(err, batch.Abort)
+	is.Equal(n, 0)
 	is.Equal(len(ranges), 1)
 	is.Equal(ranges[0].start, 0)
 	is.Equal(ranges[0].end, 9)
@@ -118,7 +121,7 @@ func TestErr(t *testing.T) {
 	}
 	var ranges []r
 	errTest := errors.New("something went wrong")
-	err := batch.All(20, 10, func(start, end int) error {
+	_, err := batch.All(20, 10, func(start, end int) error {
 		ranges = append(ranges, r{
 			start: start,
 			end:   end,


### PR DESCRIPTION
@matryer Thanks for this little code which makes go shine.

I have decided to send a PR rather than creating an issue. I just wanted to know your opinions.

I have separate them in two commits. 

The first one emphasized on returning Abort error. I feel like returning an Abort is the same as all items has been processed. There is no way to indicate whether all is done or it is been aborted.

The second commit focus on returning the number of processed items in batch. Similar to `io.Reader.Read()` which returns the number of bytes that has been read.

any thoughts on that?
cheers
